### PR TITLE
8 fixdeadlock

### DIFF
--- a/GoogleAnalyticsBQ/README.md
+++ b/GoogleAnalyticsBQ/README.md
@@ -11,7 +11,7 @@ Prerequisites:
 
 Setting up:
 * Install the plugin on the Splunk server.
-* Run the "get_tokens.py" script on your splunk server. 
+* Run the "get_tokens.py" script on your splunk server.
     * You need the project client ID and secret
     * Copy the URL into a browser, login as an account that can read the data from your BQ project, and approve the request
     * Paste the code back into the script.
@@ -40,10 +40,11 @@ Start table ingest=dto-analytics:71601106.ga_sessions_20140827
 
 Finished table ingest=dto-analytics:71601106.ga_sessions_20140826 chunkcount=28 hitcount=139949 sessioncount=81489
 
-hitcount and sessioncount are how many hits and sessions were in that day's logs, and chunkcount gives you an idea of how large the data transfer was - each chunk is around 20Mb. On the test site with roughly 140-200k hits / 55-80k sessions per day, the data size was about 500Mb. 
+hitcount and sessioncount are how many hits and sessions were in that day's logs, and chunkcount gives you an idea of how large the data transfer was - each chunk is around 20Mb. On the test site with roughly 140-200k hits / 55-80k sessions per day, the data size was about 500Mb.
 
 An input created with dataset=* will consume any gap dataset it finds without discrimination, and will continue until there are none left.
 
-If, for some reason, you need to reload a day's logs, you need to know the table name, dataset name (same as the viewID) and project name. Once you do, run "index=<whatever> source=projectname:datasetname.tablename | delete". On the next pass the input will collect the data again.
+If, for some reason, you need to reload a day's logs, you need to know the table name, dataset name (same as the viewID) and project name. Once you do, run "index=<whatever> source=projectname:datasetname.tablename | delete". Then create a lookup called "forceupdate.csv" (doesn't matter what app) with a single column (doesn't matter what name). Include the datasets you want to reindex as the values of the column.
+On the next pass the input will collect the data again and delete the lookup.
 
-If the input says it can't see any datasets, make sure the account you grabbed tokens from can actually use that project by going into the BQ console and checking. If, for example, the account previously had access but currently does not, I found that BQ returned 200 OK for the request for datasets against the project but did not show any datasets. 
+If the input says it can't see any datasets, make sure the account you grabbed tokens from can actually use that project by going into the BQ console and checking. If, for example, the account previously had access but currently does not, I found that BQ returned 200 OK for the request for datasets against the project but did not show any datasets.

--- a/GoogleAnalyticsBQ/README/inputs.conf.spec
+++ b/GoogleAnalyticsBQ/README/inputs.conf.spec
@@ -15,9 +15,8 @@ oauth2_client_secret= <value>
 * ie: (http://10.10.1.10:3128 or http://user:pass@10.10.1.10:3128 or https://10.10.1.10:1080 etc...)
 https_proxy= <value>
 
-* time to wait for reconnect after timeout or error
-backoff_time= <value>
+* Turn on verbose logging
+verbose_logging= <value>
 
-* whether or not to index http error response codes
-index_errors= <value>
-
+* Worker process count
+worker_count= <value>

--- a/GoogleAnalyticsBQ/bin/gabq.py
+++ b/GoogleAnalyticsBQ/bin/gabq.py
@@ -47,8 +47,8 @@ class GABQInput(Script):
 		scheme.add_argument(Argument(name="oauth2_client_id", description="OAuth2 Client ID", required_on_create=True))
 		scheme.add_argument(Argument(name="oauth2_client_secret", description="OAuth2 Client Secret", required_on_create=True))
 		scheme.add_argument(Argument(name="https_proxy", description="HTTPS proxy (blank if none)"))
-		scheme.add_argument(Argument(name="index_errors", description="Index any errors : true | false"))
-		scheme.add_argument(Argument(name="backoff_time", description="How long to wait after an error (seconds)"))
+		scheme.add_argument(Argument(name="verbose_logging", description="Verbose logging: true | false"))
+		scheme.add_argument(Argument(name="worker_count", description="Number of worker processes (def: 10)"))
 		return scheme
 
 	def validate_input(self, inputs):
@@ -164,30 +164,20 @@ class GABQInput(Script):
 					ew.log(EventWriter.ERROR, "Query error: %s did not return expected field %s, saw %s" % (url, item, str(response.keys())) )
 			return result
 
-		def downloader(state, tokenLock, ew, job):
+		def downloader(state, tokenLock, ew, job, startRow, rowCount):
 			# job = { url dataset table startRow rowCount dsLength schema input }
 			pid = os.getpid()
-			ew.log(EventWriter.INFO, "P: %s Start chunk ingest=%s @ %s" % (pid, job['table'], job['startRow']))
-			if job['dsLength'] - job['startRow'] > 1000:
-				params = {'maxResults': 1000, 'startIndex': job['startRow']}
-			else:
-				params = {'maxResults': job['dsLength'] - job['startRow'], 'startIndex': job['startRow']}
+			ew.log(EventWriter.INFO, "P: %s Start chunk ingest=%s @ %s" % (pid, job['table'], startRow))
+			params = {'maxResults': rowCount, 'startIndex': startRow}
 			response = fetchData(ew, state, tokenLock, job['url'], params=params)
 			if response.status_code != 200:
 				ew.log(EventWriter.ERROR, "P: %s Query error: URL %s, startPoint %s, response code %s, body %s" %
-											( pid, job['url'], params, job['startRow'], response.status_code, response.text ) )
+											( pid, job['url'], params, startRow, response.status_code, response.text ) )
 			dataDict = json.loads(response.text)
 			# Join the data chunk with the table schema
 			results = extractFields(job['schema'], dataDict)
 			sessions = []
 			hits = []
-
-			# If the retreval was not a full set of records then push a new job back into the queue for the remaining records
-			if job['startRow'] + len(results) != job['dsLength']:
-				ew.log(EventWriter.INFO, "P: %s Reinsert chunk ingest=%s @ startpoint %s, prevresults %s, dsLen %s" % (pid, job['table'], job['startRow']+len(results), len(results), job['dsLength']))
-				downloadQueue.put({'url': job['url'], 'dataset': job['dataset'], 'table': job['table'],
-									'startRow': job['startRow'] + len(results),
-									'dsLength': job['dsLength'], 'schema': job['schema'], 'input': job['input']})
 
 			# Process each row into its base session and hit elements
 			for r in results:
@@ -223,27 +213,49 @@ class GABQInput(Script):
 									stanza=job['input'],
 									time=hit['hitTime']))
 
-			# update counters
-			ew.log(EventWriter.INFO, "P: %s End chunk ingest=%s @ %s, %s" % (pid, job['table'], job['startRow'], len(sessions)))
+			# If the retreval was not a full set of records then recurse until the set is completed
+			if startRow + len(results) != rowCount:
+				# See if we can free some memory.
+				del sessions
+				del hits
+				del results
+				del response
+				del dataDict
+				downloader(state, tokenLock, ew, job, startRow +len(results), rowCount - len(results))
+
+			ew.log(EventWriter.INFO, "P: %s End chunk ingest=%s @ %s, %s" % (pid, job['table'], startRow, len(sessions)))
 			return
 
-		def downloadManager(downloadQueue, state, processingState, tokenLock, ew):
-			max_procs = 10
+		def downloadManager(downloadQueue, state, processingState, tokenLock, ew, worker_count = 10):
 			jobruncounter = 0
+			firstJob = True
 			childProcesses = []
 			ew.log(EventWriter.INFO, "DM started %s" % os.getpid())
 			# Keep spawning consumers until either the parent says there are no more job to be added to the queue
 			# (by unsetting processingState) or the queue is empty and until there are no running children.
 			while (processingState.is_set()) or (not downloadQueue.empty()) or (len(multiprocessing.active_children()) > 0):
-				if len(multiprocessing.active_children()) < max_procs:
-					try:
-						# This will wait at most 5 seconds for a job; otherwise raise Empty.
-						# Need to do this to track completion notification from the main process.
-						job = downloadQueue.get(True, 5)
-						x = multiprocessing.Process(target=downloader, args=(state, tokenLock, ew, job))
-						x.start()
-						childProcesses.append(x)
-						downloadQueue.task_done()
+				try:
+					# This will wait at most 5 seconds for a job; otherwise raise Empty.
+					# Need to do this to track completion notification from the main process.
+					# job = { url dataset table dsLength schema input }
+					job = downloadQueue.get(True, 5)
+					startRow = 0
+					while startRow < job['dsLength']:
+						# Wait until we are below the worker count limit
+						while len(multiprocessing.active_children()) > worker_count - 1: time.sleep(1)
+						# Start a job
+						# Run the first job inline. This forces the EW class to initialise the output correctly for Splunk.
+						if startRow + 1000 > job['dsLength']:
+							rowCount = job['dsLength']
+						else:
+							rowCount = 1000
+						if firstJob:
+							downloader(state, tokenLock, ew, job, startRow, rowCount)
+							firstJob = False
+						else:
+							x = multiprocessing.Process(target=downloader, args=(state, tokenLock, ew, job, startRow, rowCount))
+							x.start()
+						startRow += 1000
 						jobruncounter += 1
 						# Every hundred jobs report on the queue state and process numbers.
 						if jobruncounter % 100 == 0:
@@ -251,15 +263,11 @@ class GABQInput(Script):
 							for i in multiprocessing.active_children():
 								children.append(i.pid)
 							ew.log(EventWriter.INFO, "DM Status: %s jobs started. Children: %s" % (jobruncounter, children))
-					except Empty:
-						time.sleep(1)
+					# Finish the job
+					downloadQueue.task_done()
 
-				# Explicitly join finished children.
-				for i in childProcesses[:]:
-					if not i.is_alive():
-						i.join()
-						childProcesses.remove(i)
-
+				except Empty:
+					time.sleep(1)
 			ew.log(EventWriter.INFO, "DM finished, %s jobs total" % jobruncounter)
 			return
 
@@ -318,10 +326,20 @@ class GABQInput(Script):
 					for result in ResultsReader(splunk_job):
 						completedTables.append(result['source'])
 
+					# Remove datasets which are being forced in
+					splunk_job = service.jobs.oneshot('| inputlookup forceupload.csv', **query_mode)
+					for result in ResultsReader(splunk_job):
+						if result[result.keys()[0]] in completedTables:
+							completedTables.remove(result[result.keys()[0]])
+
 					# Process each dataset
 					gaTables = 0
 					ingestCount = 0
-					downloadManagerProcess = multiprocessing.Process(target=downloadManager, args=(downloadQueue, state, processingState, tokenLock, ew))
+					if "worker_count" in input_item.keys():
+						downloadManagerProcess = multiprocessing.Process(target=downloadManager, args=(downloadQueue, state, processingState, tokenLock, ew, int(input_item['worker_count'])))
+					else:
+						downloadManagerProcess = multiprocessing.Process(target=downloadManager, args=(downloadQueue, state, processingState, tokenLock, ew))
+					downloadManagerProcess.start()
 					for dataset in datasets:
 						# Set processing timezone
 						try:
@@ -357,14 +375,8 @@ class GABQInput(Script):
 									# Inject the dataset ID, page checkpoints and page counts into the download queue
 									# job = { url dataset startRow dsLength schema input }
 									downloadQueue.put({'url': bq_tables_url, 'dataset': dataset, 'table': table['id'],
-														 'startRow': 0, 'dsLength': int(schemaDict['numRows']), 'schema': schemaDict['schema'],
+														 'dsLength': int(schemaDict['numRows']), 'schema': schemaDict['schema'],
 														 'input': input_name})
-									if ingestCount == 1:
-										# if we have not already started the DM then start it now
-										job = downloadQueue.get(True)
-										downloader(state, tokenLock, ew, job)
-										downloadQueue.task_done()
-										downloadManagerProcess.start()
 
 					# Tell the downloadManager there are no more jobs to be added.
 					processingState.clear()
@@ -375,6 +387,8 @@ class GABQInput(Script):
 						downloadManagerProcess.join()
 					ew.log(EventWriter.INFO, "Finished ingest pass, tablecount=%s ingestcount=%s" % (gaTables, ingestCount))
 					dataManager.shutdown()
+					# Ensure any forced jobs are cleared.
+					splunk_job = service.jobs.oneshot('| outputlookup forceupload.csv create_empty=false', **query_mode)
 					time.sleep(1800)
 
 		except Exception, e:

--- a/GoogleAnalyticsBQ/default/app.conf
+++ b/GoogleAnalyticsBQ/default/app.conf
@@ -11,6 +11,5 @@ label = GoogleAnalytics-BQ
 
 [launcher]
 author = Mark McKenzie
-description = 
-version = 1.1
-
+description =
+version = 1.2


### PR DESCRIPTION
Refactor around the way jobs are queued and the involvement of the dlManager in the processing.

Included a small function to force a reindex of a dataset. 

The end result is that this should be significantly more thread safe and stable.
